### PR TITLE
Make planet edit compiling and crash less frequently.

### DIFF
--- a/src/projects/planeted/cameras.cpp
+++ b/src/projects/planeted/cameras.cpp
@@ -54,42 +54,42 @@ void MachCameras::initialise(W4dSceneManager* pSceneManager, W4dRoot* pRoot)
 
     pKeyTranslator_ = new DevKeyToCommandTranslator();
     pKeyTranslator_->addTranslation(DevKeyToCommand(
-        DevKey::F2,
+        Device::KeyCode::F2,
         ZENITHVIEW,
         DevKeyToCommand::EITHER,
         DevKeyToCommand::EITHER,
         DevKeyToCommand::EITHER));
     pKeyTranslator_->addTranslation(DevKeyToCommand(
-        DevKey::F3,
+        Device::KeyCode::F3,
         SUPERHIGHZENITHVIEW,
         DevKeyToCommand::EITHER,
         DevKeyToCommand::EITHER,
         DevKeyToCommand::EITHER));
     pKeyTranslator_->addTranslation(DevKeyToCommand(
-        DevKey::F1,
+        Device::KeyCode::F1,
         GROUNDVIEW,
         DevKeyToCommand::EITHER,
         DevKeyToCommand::EITHER,
         DevKeyToCommand::EITHER));
     pKeyTranslator_->addTranslation(DevKeyToCommand(
-        DevKey::F4,
+        Device::KeyCode::F4,
         FIRSTPERSONVIEW,
         DevKeyToCommand::EITHER,
         DevKeyToCommand::EITHER,
         DevKeyToCommand::EITHER));
-    //  pKeyTranslator_->addTranslation( DevKeyToCommand( DevKey::PAD_3, THIRDPERSONVIEW, DevKeyToCommand::EITHER,
+    //  pKeyTranslator_->addTranslation( DevKeyToCommand( Device::KeyCode::PAD_3, THIRDPERSONVIEW, DevKeyToCommand::EITHER,
     //  DevKeyToCommand::EITHER, DevKeyToCommand::EITHER ) ); pKeyTranslator_->addTranslation( DevKeyToCommand(
-    //  DevKey::F5, SAVEVIEW1, DevKeyToCommand::PRESSED, DevKeyToCommand::EITHER, DevKeyToCommand::EITHER ) );
-    //  pKeyTranslator_->addTranslation( DevKeyToCommand( DevKey::F6, SAVEVIEW2, DevKeyToCommand::PRESSED,
+    //  Device::KeyCode::F5, SAVEVIEW1, DevKeyToCommand::PRESSED, DevKeyToCommand::EITHER, DevKeyToCommand::EITHER ) );
+    //  pKeyTranslator_->addTranslation( DevKeyToCommand( Device::KeyCode::F6, SAVEVIEW2, DevKeyToCommand::PRESSED,
     //  DevKeyToCommand::EITHER, DevKeyToCommand::EITHER ) ); pKeyTranslator_->addTranslation( DevKeyToCommand(
-    //  DevKey::F7, SAVEVIEW3, DevKeyToCommand::PRESSED, DevKeyToCommand::EITHER, DevKeyToCommand::EITHER ) );
-    //  pKeyTranslator_->addTranslation( DevKeyToCommand( DevKey::F8, SAVEVIEW4, DevKeyToCommand::PRESSED,
+    //  Device::KeyCode::F7, SAVEVIEW3, DevKeyToCommand::PRESSED, DevKeyToCommand::EITHER, DevKeyToCommand::EITHER ) );
+    //  pKeyTranslator_->addTranslation( DevKeyToCommand( Device::KeyCode::F8, SAVEVIEW4, DevKeyToCommand::PRESSED,
     //  DevKeyToCommand::EITHER, DevKeyToCommand::EITHER ) ); pKeyTranslator_->addTranslation( DevKeyToCommand(
-    //  DevKey::F5, RESTOREVIEW1, DevKeyToCommand::RELEASED, DevKeyToCommand::RELEASED, DevKeyToCommand::RELEASED ) );
-    //  pKeyTranslator_->addTranslation( DevKeyToCommand( DevKey::F6, RESTOREVIEW2, DevKeyToCommand::RELEASED,
+    //  Device::KeyCode::F5, RESTOREVIEW1, DevKeyToCommand::RELEASED, DevKeyToCommand::RELEASED, DevKeyToCommand::RELEASED ) );
+    //  pKeyTranslator_->addTranslation( DevKeyToCommand( Device::KeyCode::F6, RESTOREVIEW2, DevKeyToCommand::RELEASED,
     //  DevKeyToCommand::RELEASED, DevKeyToCommand::RELEASED ) ); pKeyTranslator_->addTranslation( DevKeyToCommand(
-    //  DevKey::F7, RESTOREVIEW3, DevKeyToCommand::RELEASED, DevKeyToCommand::RELEASED, DevKeyToCommand::RELEASED ) );
-    //  pKeyTranslator_->addTranslation( DevKeyToCommand( DevKey::F8, RESTOREVIEW4, DevKeyToCommand::RELEASED,
+    //  Device::KeyCode::F7, RESTOREVIEW3, DevKeyToCommand::RELEASED, DevKeyToCommand::RELEASED, DevKeyToCommand::RELEASED ) );
+    //  pKeyTranslator_->addTranslation( DevKeyToCommand( Device::KeyCode::F8, RESTOREVIEW4, DevKeyToCommand::RELEASED,
     //  DevKeyToCommand::RELEASED, DevKeyToCommand::RELEASED ) );
     pKeyTranslator_->initEventQueue();
 

--- a/src/projects/planeted/editactor.cpp
+++ b/src/projects/planeted/editactor.cpp
@@ -59,39 +59,39 @@ void PedActorEditor::processInput(const DevButtonEvent& devButtonEvent)
 
     if (devButtonEvent.action() == DevButtonEvent::PRESS and active_)
     {
-        if (devButtonEvent.scanCode() == DevKey::KEY_D and pVertexMarker_)
+        if (devButtonEvent.scanCode() == Device::KeyCode::KEY_D and pVertexMarker_)
         {
             processDrop();
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_I)
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_I)
         {
             processCycle(PREV);
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_O)
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_O)
         {
             processCycle(NEXT);
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_C)
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_C)
         {
             processRace();
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_Y)
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_Y)
         {
             processMove(UP);
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_B)
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_B)
         {
             processMove(DOWN);
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_H)
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_H)
         {
             processMove(RIGHT);
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_G)
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_G)
         {
             processMove(LEFT);
         }
-        else if (devButtonEvent.scanCode() == DevKey::LEFT_MOUSE and pVertexMarker_)
+        else if (devButtonEvent.scanCode() == Device::KeyCode::MOUSE_LEFT and pVertexMarker_)
         {
             processSelection();
             /*   if( not alreadySelected_ )
@@ -105,12 +105,12 @@ void PedActorEditor::processInput(const DevButtonEvent& devButtonEvent)
                 mouseDrag_ = true;
             } */
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_X and devButtonEvent.wasShiftPressed())
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_X and devButtonEvent.wasShiftPressed())
         {
             processDelete();
         }
     }
-    if (devButtonEvent.action() == DevButtonEvent::RELEASE and devButtonEvent.scanCode() == DevKey::LEFT_MOUSE)
+    if (devButtonEvent.action() == DevButtonEvent::RELEASE and devButtonEvent.scanCode() == Device::KeyCode::MOUSE_LEFT)
     {
         processReleaseSelection();
     }

--- a/src/projects/planeted/editactor.hpp
+++ b/src/projects/planeted/editactor.hpp
@@ -31,6 +31,8 @@ class MachLogPlanet;
 class MexPoint3d;
 class MexTransform3d;
 
+using string = std::string;
+
 class PedActorEditor : public PedEditorMode
 // Canonical form revoked
 {

--- a/src/projects/planeted/editart.cpp
+++ b/src/projects/planeted/editart.cpp
@@ -54,32 +54,32 @@ void PedArtefactEditor::processInput(const DevButtonEvent& devButtonEvent)
     PedActorEditor::processInput(devButtonEvent);
     if (devButtonEvent.action() == DevButtonEvent::PRESS && active_)
     {
-        if (devButtonEvent.scanCode() == DevKey::KEY_L)
+        if (devButtonEvent.scanCode() == Device::KeyCode::KEY_L)
         {
             processRotation(true);
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_K)
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_K)
         {
             processRotation(false);
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_J && !devButtonEvent.wasShiftPressed())
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_J && !devButtonEvent.wasShiftPressed())
         {
             processHeightChange(1);
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_J && devButtonEvent.wasShiftPressed())
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_J && devButtonEvent.wasShiftPressed())
         {
             processHeightChange(10);
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_N && !devButtonEvent.wasShiftPressed())
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_N && !devButtonEvent.wasShiftPressed())
         {
             processHeightChange(-1);
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_N && devButtonEvent.wasShiftPressed())
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_N && devButtonEvent.wasShiftPressed())
         {
             processHeightChange(-10);
         }
     }
-    if (devButtonEvent.scanCode() == DevKey::KEY_3 && !devButtonEvent.wasShiftPressed()
+    if (devButtonEvent.scanCode() == Device::KeyCode::KEY_3 && !devButtonEvent.wasShiftPressed()
         && devButtonEvent.wasCtrlPressed())
     {
         processHide(hidden_);

--- a/src/projects/planeted/editcamr.hpp
+++ b/src/projects/planeted/editcamr.hpp
@@ -63,21 +63,15 @@ private:
 
     void processDrop();
 
-    PedCameraMarker* processChangeRace(PedCameraMarker*);
+    void processChangeRace();
 
     void setCameraToMarker(const PedCameraMarker&);
 
     void setMarkerToCamera(PedCameraMarker**, MachPhys::Race);
 
-    PedCameraMarker* setMarkerForRace(MachPhys::Race);
 
     // Data
-
-    PedCameraMarker* pRedMarker_;
-    PedCameraMarker* pBlueMarker_;
-    PedCameraMarker* pGreenMarker_;
-    PedCameraMarker* pYellowMarker_;
-    PedCameraMarker* pCurrentMarker_;
+    PedCameraMarker* pMarkers_[MachPhys::Race::N_RACES];
     MachPhys::Race race_;
 };
 

--- a/src/projects/planeted/editconstr.cpp
+++ b/src/projects/planeted/editconstr.cpp
@@ -72,16 +72,16 @@ void PedConstructionEditor::processInput(const DevButtonEvent& devButtonEvent)
     PedActorEditor::processInput(devButtonEvent);
     if (devButtonEvent.action() == DevButtonEvent::PRESS and active_)
     {
-        if (devButtonEvent.scanCode() == DevKey::KEY_L)
+        if (devButtonEvent.scanCode() == Device::KeyCode::KEY_L)
         {
             processRotation(true);
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_K)
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_K)
         {
             processRotation(false);
         }
     }
-    if (devButtonEvent.scanCode() == DevKey::KEY_1 and not devButtonEvent.wasShiftPressed()
+    if (devButtonEvent.scanCode() == Device::KeyCode::KEY_1 and not devButtonEvent.wasShiftPressed()
         and devButtonEvent.wasCtrlPressed())
     {
         processHide(hidden_);

--- a/src/projects/planeted/editdoma.cpp
+++ b/src/projects/planeted/editdoma.cpp
@@ -132,26 +132,26 @@ void PedDomainEditor::processInput(const DevButtonEvent& devButtonEvent)
 
     if (devButtonEvent.action() == DevButtonEvent::PRESS and active_)
     {
-        if (devButtonEvent.scanCode() == DevKey::F6 and devButtonEvent.wasShiftPressed()
+        if (devButtonEvent.scanCode() == Device::KeyCode::F6 and devButtonEvent.wasShiftPressed()
             and not devButtonEvent.wasCtrlPressed() and pSelectedPolygon_)
         {
             pSelectedPolygon_->hide(not pSelectedPolygon_->hidden());
         }
         else if (
-            devButtonEvent.scanCode() == DevKey::F6 and devButtonEvent.wasCtrlPressed()
+            devButtonEvent.scanCode() == Device::KeyCode::F6 and devButtonEvent.wasCtrlPressed()
             and not devButtonEvent.wasShiftPressed())
         {
             hidePolygons_ = not hidePolygons_;
             hidePolygons(hidePolygons_);
         }
         else if (
-            devButtonEvent.scanCode() == DevKey::KEY_V and not devButtonEvent.wasCtrlPressed() and pHighlightVertex_
+            devButtonEvent.scanCode() == Device::KeyCode::KEY_V and not devButtonEvent.wasCtrlPressed() and pHighlightVertex_
             and pSelectedVertex_)
         {
             processInsertVertex();
         }
         else if (
-            devButtonEvent.scanCode() == DevKey::KEY_X and not devButtonEvent.wasShiftPressed()
+            devButtonEvent.scanCode() == Device::KeyCode::KEY_X and not devButtonEvent.wasShiftPressed()
             and not devButtonEvent.wasCtrlPressed() and pSelectedVertex_)
         {
             processDeleteVertex();

--- a/src/projects/planeted/editmach.cpp
+++ b/src/projects/planeted/editmach.cpp
@@ -65,7 +65,7 @@ void PedMachineEditor::CLASS_INVARIANT
 void PedMachineEditor::processInput(const DevButtonEvent& devButtonEvent)
 {
     PedActorEditor::processInput(devButtonEvent);
-    if (devButtonEvent.scanCode() == DevKey::KEY_2 and not devButtonEvent.wasShiftPressed()
+    if (devButtonEvent.scanCode() == Device::KeyCode::KEY_2 and not devButtonEvent.wasShiftPressed()
         and devButtonEvent.wasCtrlPressed())
     {
         processHide(hidden_);
@@ -114,6 +114,7 @@ void PedMachineEditor::readScnFile(PedScenarioFile& scenarioFile)
                 break;
             }
         }
+        if (machDataIter_ == machineData_.end()) continue;
         // Set current race in order to create construction of the correct race
         race_ = (*scnMachIter).race;
         // Create new machine ( using machDataIter_ ) and new mapping

--- a/src/projects/planeted/editmode.hpp
+++ b/src/projects/planeted/editmode.hpp
@@ -26,6 +26,8 @@ class SysPathName;
 class MexPoint2d;
 class PedScenarioFile;
 
+using string = std::string;
+
 class PedEditorMode
 // Canonical form revoked
 {

--- a/src/projects/planeted/editobst.cpp
+++ b/src/projects/planeted/editobst.cpp
@@ -76,31 +76,31 @@ void PedObstacleEditor::processInput(const DevButtonEvent& devButtonEvent)
 
     if (devButtonEvent.action() == DevButtonEvent::PRESS and active_)
     {
-        if (devButtonEvent.scanCode() == DevKey::KEY_V and not devButtonEvent.wasCtrlPressed() and pHighlightVertex_
+        if (devButtonEvent.scanCode() == Device::KeyCode::KEY_V and not devButtonEvent.wasCtrlPressed() and pHighlightVertex_
             and pSelectedVertex_)
         {
             processInsertVertex();
         }
         else if (
-            devButtonEvent.scanCode() == DevKey::KEY_X and not devButtonEvent.wasShiftPressed()
+            devButtonEvent.scanCode() == Device::KeyCode::KEY_X and not devButtonEvent.wasShiftPressed()
             and not devButtonEvent.wasCtrlPressed() and pSelectedVertex_)
         {
             processDeleteVertex();
         }
         else if (
-            devButtonEvent.scanCode() == DevKey::F7 and devButtonEvent.wasShiftPressed()
+            devButtonEvent.scanCode() == Device::KeyCode::F7 and devButtonEvent.wasShiftPressed()
             and not devButtonEvent.wasCtrlPressed() and pSelectedPolygon_)
         {
             pSelectedPolygon_->hide(not pSelectedPolygon_->hidden());
         }
         else if (
-            devButtonEvent.scanCode() == DevKey::KEY_K and not devButtonEvent.wasCtrlPressed() and pSelectedPolygon_)
+            devButtonEvent.scanCode() == Device::KeyCode::KEY_K and not devButtonEvent.wasCtrlPressed() and pSelectedPolygon_)
         {
             size_t heightChange = devButtonEvent.wasShiftPressed() ? 10 : 1;
             pSelectedPolygon_->height(pSelectedPolygon_->height() + heightChange);
         }
         else if (
-            devButtonEvent.scanCode() == DevKey::KEY_L and not devButtonEvent.wasCtrlPressed() and pSelectedPolygon_)
+            devButtonEvent.scanCode() == Device::KeyCode::KEY_L and not devButtonEvent.wasCtrlPressed() and pSelectedPolygon_)
         {
             size_t heightChange = devButtonEvent.wasShiftPressed() ? 10 : 1;
 
@@ -109,20 +109,20 @@ void PedObstacleEditor::processInput(const DevButtonEvent& devButtonEvent)
                 pSelectedPolygon_->height(pSelectedPolygon_->height() - heightChange);
             }
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_P and not devButtonEvent.wasShiftPressed())
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_P and not devButtonEvent.wasShiftPressed())
         {
             processDisplayVerticalPolygons(true);
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_P and devButtonEvent.wasShiftPressed())
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_P and devButtonEvent.wasShiftPressed())
         {
             processDisplayVerticalPolygons(false);
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_P and devButtonEvent.wasCtrlPressed())
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_P and devButtonEvent.wasCtrlPressed())
         {
             processComputeVerticalPolygons();
             processDisplayVerticalPolygons(true);
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_N and not devButtonEvent.wasShiftPressed())
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_N and not devButtonEvent.wasShiftPressed())
         {
             PedObstacle::highlightedType(PedObstacle::NORMAL);
             if (pSelectedPolygon_)
@@ -130,12 +130,12 @@ void PedObstacleEditor::processInput(const DevButtonEvent& devButtonEvent)
                 processChangeObstacleType();
             }
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_N and devButtonEvent.wasShiftPressed())
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_N and devButtonEvent.wasShiftPressed())
         {
             PedObstacle::highlightedType(PedObstacle::NORMAL);
             highlightAllObstacles();
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_W and not devButtonEvent.wasShiftPressed())
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_W and not devButtonEvent.wasShiftPressed())
         {
             PedObstacle::highlightedType(PedObstacle::WATER);
             if (pSelectedPolygon_)
@@ -143,12 +143,12 @@ void PedObstacleEditor::processInput(const DevButtonEvent& devButtonEvent)
                 processChangeObstacleType();
             }
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_W and devButtonEvent.wasShiftPressed())
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_W and devButtonEvent.wasShiftPressed())
         {
             PedObstacle::highlightedType(PedObstacle::WATER);
             highlightAllObstacles();
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_E and not devButtonEvent.wasShiftPressed())
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_E and not devButtonEvent.wasShiftPressed())
         {
             PedObstacle::highlightedType(PedObstacle::LOW);
             if (pSelectedPolygon_)
@@ -156,13 +156,13 @@ void PedObstacleEditor::processInput(const DevButtonEvent& devButtonEvent)
                 processChangeObstacleType();
             }
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_E and devButtonEvent.wasShiftPressed())
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_E and devButtonEvent.wasShiftPressed())
         {
             PedObstacle::highlightedType(PedObstacle::LOW);
             highlightAllObstacles();
         }
     }
-    if (devButtonEvent.action() == DevButtonEvent::PRESS and devButtonEvent.scanCode() == DevKey::F7
+    if (devButtonEvent.action() == DevButtonEvent::PRESS and devButtonEvent.scanCode() == Device::KeyCode::F7
         and devButtonEvent.wasCtrlPressed() and not devButtonEvent.wasShiftPressed())
     {
         hidePolygons_ = not hidePolygons_;

--- a/src/projects/planeted/editpoly.cpp
+++ b/src/projects/planeted/editpoly.cpp
@@ -55,24 +55,24 @@ void PedPolygonEditor::processInput(const DevButtonEvent& devButtonEvent)
 {
     if (devButtonEvent.action() == DevButtonEvent::PRESS and active_)
     {
-        if (devButtonEvent.scanCode() == DevKey::LEFT_MOUSE and pHighlightVertex_ and not mouseDrag_)
+        if (devButtonEvent.scanCode() == Device::KeyCode::MOUSE_LEFT and pHighlightVertex_ and not mouseDrag_)
         {
             processSelectPolygon();
         }
 
-        else if (devButtonEvent.scanCode() == DevKey::KEY_D and pHighlightVertex_)
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_D and pHighlightVertex_)
         {
             processDropPolygon();
         }
         else if (
-            devButtonEvent.scanCode() == DevKey::KEY_X and devButtonEvent.wasShiftPressed()
+            devButtonEvent.scanCode() == Device::KeyCode::KEY_X and devButtonEvent.wasShiftPressed()
             and not devButtonEvent.wasCtrlPressed() and pSelectedPolygon_)
         {
             // Delete polygon
             processDeletePolygon();
         }
         else if (
-            devButtonEvent.scanCode() == DevKey::KEY_X and not devButtonEvent.wasShiftPressed()
+            devButtonEvent.scanCode() == Device::KeyCode::KEY_X and not devButtonEvent.wasShiftPressed()
             and devButtonEvent.wasCtrlPressed() and pSelectedPolygon_)
         {
             // Cut polygon
@@ -81,49 +81,49 @@ void PedPolygonEditor::processInput(const DevButtonEvent& devButtonEvent)
         }
 
         else if (
-            devButtonEvent.scanCode() == DevKey::KEY_I and devButtonEvent.wasShiftPressed() and not polygons_.empty())
+            devButtonEvent.scanCode() == Device::KeyCode::KEY_I and devButtonEvent.wasShiftPressed() and not polygons_.empty())
         {
             processPrevPolygon();
         }
         else if (
-            devButtonEvent.scanCode() == DevKey::KEY_I and not devButtonEvent.wasShiftPressed()
+            devButtonEvent.scanCode() == Device::KeyCode::KEY_I and not devButtonEvent.wasShiftPressed()
             and not polygons_.empty())
         {
             processPrevVertex();
         }
         else if (
-            devButtonEvent.scanCode() == DevKey::KEY_O and not devButtonEvent.wasShiftPressed()
+            devButtonEvent.scanCode() == Device::KeyCode::KEY_O and not devButtonEvent.wasShiftPressed()
             and not polygons_.empty())
         {
             processNextVertex();
         }
         else if (
-            devButtonEvent.scanCode() == DevKey::KEY_O and devButtonEvent.wasShiftPressed() and not polygons_.empty())
+            devButtonEvent.scanCode() == Device::KeyCode::KEY_O and devButtonEvent.wasShiftPressed() and not polygons_.empty())
         {
             processNextPolygon();
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_H)
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_H)
         {
             if (devButtonEvent.wasShiftPressed())
                 processPolygonRight();
             else
                 processVertexRight();
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_G)
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_G)
         {
             if (devButtonEvent.wasShiftPressed())
                 processPolygonLeft();
             else
                 processVertexLeft();
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_Y)
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_Y)
         {
             if (devButtonEvent.wasShiftPressed())
                 processPolygonUp();
             else
                 processVertexUp();
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_B)
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_B)
         {
             if (devButtonEvent.wasShiftPressed())
                 processPolygonDown();
@@ -131,29 +131,29 @@ void PedPolygonEditor::processInput(const DevButtonEvent& devButtonEvent)
                 processVertexDown();
         }
         else if (
-            devButtonEvent.scanCode() == DevKey::KEY_V and not devButtonEvent.wasShiftPressed()
+            devButtonEvent.scanCode() == Device::KeyCode::KEY_V and not devButtonEvent.wasShiftPressed()
             and devButtonEvent.wasCtrlPressed())
         {
             processPaste(true);
         }
         else if (
-            devButtonEvent.scanCode() == DevKey::KEY_C and not devButtonEvent.wasShiftPressed()
+            devButtonEvent.scanCode() == Device::KeyCode::KEY_C and not devButtonEvent.wasShiftPressed()
             and devButtonEvent.wasCtrlPressed() and pSelectedPolygon_)
         {
             copyVerticies_ = pSelectedPolygon_->verticies();
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_F)
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_F)
         {
             processFlattenPolygons();
         }
     }
 
-    if (devButtonEvent.action() == DevButtonEvent::RELEASE and devButtonEvent.scanCode() == DevKey::LEFT_MOUSE)
+    if (devButtonEvent.action() == DevButtonEvent::RELEASE and devButtonEvent.scanCode() == Device::KeyCode::MOUSE_LEFT)
     {
         mouseDrag_ = false;
     }
 
-    if (devButtonEvent.action() == DevButtonEvent::RELEASE and devButtonEvent.scanCode() == DevKey::KEY_V
+    if (devButtonEvent.action() == DevButtonEvent::RELEASE and devButtonEvent.scanCode() == Device::KeyCode::KEY_V
         and pPastePolygon_ and active_)
     {
         processPaste(false);

--- a/src/projects/planeted/editport.cpp
+++ b/src/projects/planeted/editport.cpp
@@ -109,18 +109,18 @@ void PedPortalEditor::processInput(const DevButtonEvent& devButtonEvent)
 
     if (devButtonEvent.action() == DevButtonEvent::PRESS and active_)
     {
-        if (devButtonEvent.scanCode() == DevKey::KEY_P)
+        if (devButtonEvent.scanCode() == Device::KeyCode::KEY_P)
         {
             processCreatePortalsFromDomains();
         }
-        if (devButtonEvent.scanCode() == DevKey::F8 and devButtonEvent.wasShiftPressed()
+        if (devButtonEvent.scanCode() == Device::KeyCode::F8 and devButtonEvent.wasShiftPressed()
             and not devButtonEvent.wasCtrlPressed() and pSelectedPolygon_)
         {
             pSelectedPolygon_->hide(not pSelectedPolygon_->hidden());
         }
     }
 
-    if (devButtonEvent.action() == DevButtonEvent::PRESS and devButtonEvent.scanCode() == DevKey::F8
+    if (devButtonEvent.action() == DevButtonEvent::PRESS and devButtonEvent.scanCode() == Device::KeyCode::F8
         and devButtonEvent.wasCtrlPressed() and not devButtonEvent.wasShiftPressed())
     {
         hidePolygons_ = not hidePolygons_;

--- a/src/projects/planeted/edittile.cpp
+++ b/src/projects/planeted/edittile.cpp
@@ -80,7 +80,7 @@ void PedTileEditor::processInput(const DevButtonEvent& devButtonEvent)
 {
     if (devButtonEvent.action() == DevButtonEvent::PRESS and active_)
     {
-        if (devButtonEvent.scanCode() == DevKey::LEFT_MOUSE)
+        if (devButtonEvent.scanCode() == Device::KeyCode::MOUSE_LEFT)
         {
             if (not devButtonEvent.wasCtrlPressed())
             {
@@ -88,39 +88,39 @@ void PedTileEditor::processInput(const DevButtonEvent& devButtonEvent)
             }
             processSelection(devButtonEvent);
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_L)
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_L)
         {
             processRotation(true);
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_K)
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_K)
         {
             processRotation(false);
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_U)
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_U)
         {
             processHeightChange(true, devButtonEvent.wasShiftPressed());
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_D)
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_D)
         {
             processHeightChange(false, devButtonEvent.wasShiftPressed());
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_I)
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_I)
         {
             processCycleTile(PREV);
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_O)
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_O)
         {
             processCycleTile(NEXT);
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_P)
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_P)
         {
             processCycleTile(CURRENT);
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_C and not devButtonEvent.wasShiftPressed())
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_C and not devButtonEvent.wasShiftPressed())
         {
             processAttatchCeilingArtefact(true);
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_C and devButtonEvent.wasShiftPressed())
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_C and devButtonEvent.wasShiftPressed())
         {
             processAttatchCeilingArtefact(false);
         }

--- a/src/projects/planeted/leaktrak.cpp
+++ b/src/projects/planeted/leaktrak.cpp
@@ -23,7 +23,7 @@ void LeakTracker::update(Action action, SampleRate rate)
         case INLOOP:
             {
                 // Check for a new keypress on F12
-                bool f12Hit = not f12Down and DevKeyboard::instance().keyCode(DevKey::F12);
+                bool f12Hit = not f12Down and DevKeyboard::instance().keyCode(Device::KeyCode::F12);
                 if (f12Hit)
                     f12Down = true;
                 else

--- a/src/projects/planeted/planeted.cpp
+++ b/src/projects/planeted/planeted.cpp
@@ -276,49 +276,49 @@ void PedPlanetEditor::readArfFile(const SysPathName& arfFileName)
 void PedPlanetEditor::initDeviceEvents()
 {
     // Setup event queue to respond to certain key pressed
-    DevEventQueue::instance().queueEvents(DevKey::LEFT_MOUSE, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::LEFT_MOUSE, DevButtonEvent::RELEASE);
-    DevEventQueue::instance().queueEvents(DevKey::ESCAPE, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::F1, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::F2, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::F4, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::F5, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::F6, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::F7, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::F8, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::F9, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::F10, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::F11, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::F12, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::KEY_B, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::KEY_C, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::KEY_D, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::KEY_E, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::KEY_F, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::KEY_G, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::KEY_H, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::KEY_I, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::KEY_J, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::KEY_K, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::KEY_L, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::KEY_N, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::KEY_O, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::KEY_P, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::KEY_Q, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::KEY_R, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::KEY_S, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::KEY_U, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::KEY_V, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::KEY_V, DevButtonEvent::RELEASE);
-    DevEventQueue::instance().queueEvents(DevKey::KEY_W, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::KEY_X, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::KEY_Y, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::KEY_1, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::KEY_2, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::KEY_3, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::KEY_4, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::HOME, DevButtonEvent::PRESS);
-    DevEventQueue::instance().queueEvents(DevKey::END, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::MOUSE_LEFT, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::MOUSE_LEFT, DevButtonEvent::RELEASE);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::ESCAPE, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::F1, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::F2, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::F4, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::F5, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::F6, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::F7, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::F8, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::F9, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::F10, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::F11, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::F12, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::KEY_B, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::KEY_C, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::KEY_D, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::KEY_E, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::KEY_F, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::KEY_G, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::KEY_H, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::KEY_I, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::KEY_J, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::KEY_K, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::KEY_L, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::KEY_N, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::KEY_O, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::KEY_P, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::KEY_Q, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::KEY_R, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::KEY_S, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::KEY_U, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::KEY_V, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::KEY_V, DevButtonEvent::RELEASE);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::KEY_W, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::KEY_X, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::KEY_Y, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::KEY_1, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::KEY_2, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::KEY_3, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::KEY_4, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::HOME, DevButtonEvent::PRESS);
+    DevEventQueue::instance().queueEvents(Device::KeyCode::END, DevButtonEvent::PRESS);
 }
 
 void PedPlanetEditor::processInput(const DevButtonEvent& devButtonEvent)
@@ -331,7 +331,7 @@ void PedPlanetEditor::processInput(const DevButtonEvent& devButtonEvent)
     if (devButtonEvent.action() == DevButtonEvent::PRESS)
     {
         // Check for mode change first...
-        if (devButtonEvent.scanCode() == DevKey::F5 and not devButtonEvent.wasCtrlPressed()
+        if (devButtonEvent.scanCode() == Device::KeyCode::F5 and not devButtonEvent.wasCtrlPressed()
             and not devButtonEvent.wasShiftPressed() and pCurrentMode_ != pTileMode_)
         {
             pCurrentMode_->changingMode();
@@ -339,7 +339,7 @@ void PedPlanetEditor::processInput(const DevButtonEvent& devButtonEvent)
             pCurrentMode_->activateMode();
         }
         else if (
-            devButtonEvent.scanCode() == DevKey::F6 and not devButtonEvent.wasCtrlPressed()
+            devButtonEvent.scanCode() == Device::KeyCode::F6 and not devButtonEvent.wasCtrlPressed()
             and not devButtonEvent.wasShiftPressed() and pCurrentMode_ != pDomainMode_)
         {
             pCurrentMode_->changingMode();
@@ -347,7 +347,7 @@ void PedPlanetEditor::processInput(const DevButtonEvent& devButtonEvent)
             pCurrentMode_->activateMode();
         }
         else if (
-            devButtonEvent.scanCode() == DevKey::F7 and not devButtonEvent.wasCtrlPressed()
+            devButtonEvent.scanCode() == Device::KeyCode::F7 and not devButtonEvent.wasCtrlPressed()
             and not devButtonEvent.wasShiftPressed() and pCurrentMode_ != pObstacleMode_)
         {
             pCurrentMode_->changingMode();
@@ -355,7 +355,7 @@ void PedPlanetEditor::processInput(const DevButtonEvent& devButtonEvent)
             pCurrentMode_->activateMode();
         }
         else if (
-            devButtonEvent.scanCode() == DevKey::F8 and not devButtonEvent.wasCtrlPressed()
+            devButtonEvent.scanCode() == Device::KeyCode::F8 and not devButtonEvent.wasCtrlPressed()
             and not devButtonEvent.wasShiftPressed() and pCurrentMode_ != pPortalMode_)
         {
             pCurrentMode_->changingMode();
@@ -363,7 +363,7 @@ void PedPlanetEditor::processInput(const DevButtonEvent& devButtonEvent)
             pCurrentMode_->activateMode();
         }
         else if (
-            devButtonEvent.scanCode() == DevKey::KEY_1 and not devButtonEvent.wasCtrlPressed()
+            devButtonEvent.scanCode() == Device::KeyCode::KEY_1 and not devButtonEvent.wasCtrlPressed()
             and not devButtonEvent.wasShiftPressed() and pCurrentMode_ != pConstructionMode_)
         {
             pCurrentMode_->changingMode();
@@ -371,7 +371,7 @@ void PedPlanetEditor::processInput(const DevButtonEvent& devButtonEvent)
             pCurrentMode_->activateMode();
         }
         else if (
-            devButtonEvent.scanCode() == DevKey::KEY_2 and not devButtonEvent.wasCtrlPressed()
+            devButtonEvent.scanCode() == Device::KeyCode::KEY_2 and not devButtonEvent.wasCtrlPressed()
             and not devButtonEvent.wasShiftPressed() and pCurrentMode_ != pMachineMode_)
         {
             pCurrentMode_->changingMode();
@@ -379,7 +379,7 @@ void PedPlanetEditor::processInput(const DevButtonEvent& devButtonEvent)
             pCurrentMode_->activateMode();
         }
         else if (
-            devButtonEvent.scanCode() == DevKey::KEY_3 and not devButtonEvent.wasCtrlPressed()
+            devButtonEvent.scanCode() == Device::KeyCode::KEY_3 and not devButtonEvent.wasCtrlPressed()
             and not devButtonEvent.wasShiftPressed() and pCurrentMode_ != pArtefactMode_)
         {
             pCurrentMode_->changingMode();
@@ -387,7 +387,7 @@ void PedPlanetEditor::processInput(const DevButtonEvent& devButtonEvent)
             pCurrentMode_->activateMode();
         }
         else if (
-            devButtonEvent.scanCode() == DevKey::KEY_4 and not devButtonEvent.wasCtrlPressed()
+            devButtonEvent.scanCode() == Device::KeyCode::KEY_4 and not devButtonEvent.wasCtrlPressed()
             and not devButtonEvent.wasShiftPressed() and pCurrentMode_ != pCameraMode_)
         {
             pCurrentMode_->changingMode();
@@ -395,16 +395,16 @@ void PedPlanetEditor::processInput(const DevButtonEvent& devButtonEvent)
             pCurrentMode_->activateMode();
         }
 
-        else if (devButtonEvent.scanCode() == DevKey::F10)
+        else if (devButtonEvent.scanCode() == Device::KeyCode::F10)
         {
             dispKeyboardControls_ = not dispKeyboardControls_;
         }
-        else if (devButtonEvent.scanCode() == DevKey::KEY_S)
+        else if (devButtonEvent.scanCode() == Device::KeyCode::KEY_S)
         {
             if (devButtonEvent.wasCtrlPressed())
                 processSave();
         }
-        else if (devButtonEvent.scanCode() == DevKey::F9)
+        else if (devButtonEvent.scanCode() == Device::KeyCode::F9)
         {
             //          pTileMode_->validate();
             //          pDomainMode_->validate();
@@ -412,7 +412,7 @@ void PedPlanetEditor::processInput(const DevButtonEvent& devButtonEvent)
             //          pPortalMode_->validate();
             dispWarnings_ = not dispWarnings_;
         }
-        else if (devButtonEvent.scanCode() == DevKey::F11)
+        else if (devButtonEvent.scanCode() == Device::KeyCode::F11)
         {
             // Create map bitmap
             PedMapCreator mapCreator(
@@ -421,12 +421,12 @@ void PedPlanetEditor::processInput(const DevButtonEvent& devButtonEvent)
                 *_REINTERPRET_CAST(PedPolygonEditor*, pObstacleMode_));
             mapCreator.createBmp();
         }
-        else if (devButtonEvent.scanCode() == DevKey::HOME)
+        else if (devButtonEvent.scanCode() == Device::KeyCode::HOME)
         {
             if (not ProProfiler::instance().isProfilingEnabled())
                 ProProfiler::instance().enableProfiling();
         }
-        else if (devButtonEvent.scanCode() == DevKey::END)
+        else if (devButtonEvent.scanCode() == Device::KeyCode::END)
         {
             if (ProProfiler::instance().isProfilingEnabled())
                 ProProfiler::instance().disableProfiling();

--- a/src/projects/planeted/race.hpp
+++ b/src/projects/planeted/race.hpp
@@ -14,6 +14,8 @@
 #include "render/colour.hpp"
 // #include <strfwd.hpp>
 
+using string = std::string;
+
 struct PedRace
 {
     static MachPhys::Race parse(const string& raceString);

--- a/src/projects/planeted/scenfile.hpp
+++ b/src/projects/planeted/scenfile.hpp
@@ -35,6 +35,7 @@ public:
 
     void CLASS_INVARIANT;
 
+    using string = std::string;
     using RaceAI = string;
     using MineralSite = string;
     using Miscellanious = string;

--- a/src/projects/planeted/sdlapp.cpp
+++ b/src/projects/planeted/sdlapp.cpp
@@ -653,8 +653,8 @@ void SDLApp::readEnvironment(const string& planetLeafName)
 // virtual
 void SDLApp::checkForQuit(const DevButtonEvent& devButtonEvent)
 {
-    if (devButtonEvent.scanCode() == DevKey::KEY_Q
-        or (devButtonEvent.scanCode() == DevKey::ESCAPE and devButtonEvent.wasShiftPressed()))
+    if (devButtonEvent.scanCode() == Device::KeyCode::KEY_Q
+        or (devButtonEvent.scanCode() == Device::KeyCode::ESCAPE and devButtonEvent.wasShiftPressed()))
     {
         finish();
         PhysConfigSpace2d* pConfigSpace = &pPlanet_->configSpace();

--- a/src/projects/planeted/sdlapp.hpp
+++ b/src/projects/planeted/sdlapp.hpp
@@ -21,6 +21,8 @@ class MexPoint2d;
 class MexPoint3d;
 class EnvPlanetEnvironment;
 
+using string = std::string;
+
 // This class represents an application based on Direct3D.  When we know
 // what's common to all D3D apps, this probably ought to become an abstract
 // base class.  It's based on the application framework, so there's no main,

--- a/src/projects/planeted/wdebug.hpp
+++ b/src/projects/planeted/wdebug.hpp
@@ -18,6 +18,8 @@
 
 class W4dSceneManager;
 
+using string = std::string;
+
 class wdebug
 // Canonical form revoked
 {


### PR DESCRIPTION
- Update for a Device::KeyCode namespace (replace `string` with `std::string` explicitly?).
- `pCurrentMarker_` was re-assigned but `pRedMarker_`, `pBlueMarker_` etc. were not thus not in sync pointing to a deleted object when a new camera was dropped.
- Fix a case of accessing invalid iterator `machDataIter_ == machineData_.end()`.