### PR TITLE
Gui callbacks are creating problems and crashes.

### DIFF
--- a/src/libdev/gui/button.cpp
+++ b/src/libdev/gui/button.cpp
@@ -62,6 +62,10 @@ void GuiButton::doHandleMouseClickEvent(const GuiMouseEvent& e)
     {
         if (e.leftButton() == Gui::RELEASED)
         {
+            if (clickedCallback_)
+            {
+                clickedCallback_(this);
+            }
             // Only interested in release event if we are a popupButton,
             // stay-pressed buttons are sent release event when they are pressed
             // a second time.
@@ -76,10 +80,6 @@ void GuiButton::doHandleMouseClickEvent(const GuiMouseEvent& e)
                 }
             }
 
-            if (clickedCallback_)
-            {
-                clickedCallback_(this);
-            }
         }
         else if (e.leftButton() == Gui::PRESSED)
         {

--- a/src/libdev/gui/sslistbx.cpp
+++ b/src/libdev/gui/sslistbx.cpp
@@ -56,13 +56,13 @@ void GuiSingleSelectionListBox::notifyListItemSelection(GuiSingleSelectionListBo
 
         pCurrentSelection_ = pNewSelection;
 
-        pCurrentSelection_->setSelected(true);
-        pCurrentSelection_->select();
-
         if (selectionChangedCallback_)
         {
             selectionChangedCallback_(this);
         }
+        pCurrentSelection_->setSelected(true);
+        pCurrentSelection_->select();
+        // Warn: 'this' may be deleted by itself
     }
 }
 


### PR DESCRIPTION
What was a reason for such a change? This is slippery surface of an old C++ with manual memory management. If code logic is not clearly known then deep testing of assumed changes is necessary. 
These checks for a callback (`operator bool()` ) are invoked on a deleted object sometimes - putting it before calls that may lead to `deleteAllChildren()` fix it but still getting errors when call back is executed. Please check and fix them or revert those changes.  It is getting even worse when exiting the options screen but this may be not related to this.
```
==1493259== Invalid read of size 1
==1493259==    at 0x5D93C3: GuiButton::doHandleMouseClickEvent(GuiMouseEvent const&) (button.cpp:72)
==1493259==    by 0x5EF77C: GuiManager::processMouseEvent(GuiMouseEvent const&) (manager.cpp:420)
==1493259==    by 0x5EF9A6: GuiManager::processEvents() (manager.cpp:452)
==1493259==    by 0x5EEC1F: GuiManager::update() (manager.cpp:241)
==1493259==    by 0x2E059D: MachGuiStartupScreens::updateGui() (startup.cpp:361)
==1493259==    by 0x2E51E0: MachGuiStartupScreens::loopCycleInGame() (startup.cpp:1686)
==1493259==    by 0x2E04AE: MachGuiStartupScreens::loopCycle() (startup.cpp:330)
==1493259==    by 0x1AEC65: SDLApp::loopCycle() (guistuff.cpp:129)
==1493259==    by 0x1C2610: AfxSdlApp::coreLoop() (AfxSdlApp.cpp:175)
==1493259==    by 0x1B9965: AfxApp::run() (app.cpp:16)
==1493259==    by 0x189370: main (machines_main.cpp:19)
==1493259==  Address 0x174656b2 is 50 bytes inside a block of size 248 free'd
==1493259==    at 0x484A61D: operator delete(void*, unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1493259==    by 0x3F8AB0: MachHWResearchBankIcon::~MachHWResearchBankIcon() (hwrbicon.cpp:118)
==1493259==    by 0x5DC11F: GuiDisplayable::deleteAllChildren() (displaya.cpp:352)
==1493259==    by 0x3F7B4F: MachHWResearchBankIcons::updateIcons() (hwrbicns.cpp:74)
==1493259==    by 0x3F79C1: MachHWResearchBankIcons::onIconClicked(GuiButton*) (hwrbicns.cpp:39)
==1493259==    by 0x3F7B15: MachHWResearchBankIcons::updateIcons()::{lambda(GuiButton*)#1}::operator()(GuiButton*) const (hwrbicns.cpp:86)
==1493259==    by 0x3F816B: void std::__invoke_impl<void, MachHWResearchBankIcons::updateIcons()::{lambda(GuiButton*)#1}&, GuiButton*>(std::__invoke_other, MachHWResearchBankIcons::updateIcons()::{lambda(GuiButton*)#1}&, GuiButton*&&) (invoke.h:61)
==1493259==    by 0x3F8034: std::enable_if<is_invocable_r_v<void, MachHWResearchBankIcons::updateIcons()::{lambda(GuiButton*)#1}&, GuiButton*>, void>::type std::__invoke_r<void, MachHWResearchBankIcons::updateIcons()::{lambda(GuiButton*)#1}&, GuiButton*>(MachHWResearchBankIcons::updateIcons()::{lambda(GuiButton*)#1}&, GuiButton*&&) (invoke.h:111)
==1493259==    by 0x3F7F07: std::_Function_handler<void (GuiButton*), MachHWResearchBankIcons::updateIcons()::{lambda(GuiButton*)#1}>::_M_invoke(std::_Any_data const&, GuiButton*&&) (std_function.h:290)
==1493259==    by 0x5DA586: std::function<void (GuiButton*)>::operator()(GuiButton*) const (std_function.h:591)
==1493259==    by 0x5D93BE: GuiButton::doHandleMouseClickEvent(GuiMouseEvent const&) (button.cpp:67)
==1493259==    by 0x5EF77C: GuiManager::processMouseEvent(GuiMouseEvent const&) (manager.cpp:420)
==1493259==  Block was alloc'd at
==1493259==    at 0x4846FA3: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1493259==    by 0x3F7BB2: MachHWResearchBankIcons::updateIcons() (hwrbicns.cpp:85)
==1493259==    by 0x3E6B93: MachHWResearchBank::updateQueueIcons() (hwrebank.cpp:100)
==1493259==    by 0x3E69CA: MachHWResearchBank::MachHWResearchBank(GuiDisplayable*, MexAlignedBox2d const&, MachLogHardwareLab*, MachInGameScreen*) (hwrebank.cpp:71)
==1493259==    by 0x34FD54: MachInGameScreen::setupActorBank() (ingame.cpp:2268)
==1493259==    by 0x34E721: MachInGameScreen::currentContext(MachGui::ControlPanelContext, bool) (ingame.cpp:1846)
==1493259==    by 0x34E3B1: MachInGameScreen::hardwareResearchContext() (ingame.cpp:1774)
==1493259==    by 0x34E522: MachInGameScreen::mainMenuOrSingleFactoryContext() (ingame.cpp:1810)
==1493259==    by 0x349525: MachInGameScreen::checkDismissNavigator() (ingame.cpp:674)
==1493259==    by 0x348EDA: MachInGameScreen::select(ctl_pvector<MachActor> const&) (ingame.cpp:500)
==1493259==    by 0x348C6A: MachInGameScreen::select(MachActor*) (ingame.cpp:436)
==1493259==    by 0x3B512F: MachGuiDefaultCommand::selectActors(MachActor*, bool, bool, bool) (cmddefau.cpp:334)
==1493259== 
