### PR TITLE
Fix invalid memory accesses, add PlanetEd to CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -109,6 +109,7 @@ jobs:
           -GNinja
           -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}
           -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/install/machines
+          -DBUILD_PLANETED=TRUE
           ${cmake_toolchain_args}
           ${cmake_release_args}
           RESULT_VARIABLE CONF_RESULT
@@ -129,6 +130,10 @@ jobs:
     - name: Install
       if: matrix.package
       run: cmake --build ${{github.workspace}}/build --config ${{ matrix.build-type }} --target install
+
+    - name: Remove the editor from the distribution
+      if: matrix.package
+      run: cmake -E remove ${{github.workspace}}/install/machines/planeted.exe
 
     - name: Add the data pack
       if: matrix.package

--- a/src/libdev/machgui/ProgressIndicator.hpp
+++ b/src/libdev/machgui/ProgressIndicator.hpp
@@ -15,10 +15,10 @@ public:
     void setLimits(double lower, double upper);
 
 private:
-    double lowerLimit_ = 0;
-    double upperLimit_ = 0;
-    size_t lastDone_;
-    Gui::Box area_;
+    double lowerLimit_{};
+    double upperLimit_{};
+    std::size_t lastDone_{};
+    Gui::Box area_{};
     Gui::Colour color_ {};
 };
 

--- a/src/libdev/machgui/ctxoptns.cpp
+++ b/src/libdev/machgui/ctxoptns.cpp
@@ -573,10 +573,8 @@ void MachGuiCtxOptions::buttonEvent(MachGui::ButtonEvent buttonEvent)
         {
             pGammaCorrection_->setValue(gammaCorrection_);
         }
-        pStartupScreens_->buttonAction(MachGui::ButtonEvent::EXIT);
 
-        const bool grabCursorEnabled = SysRegistry::instance().queryBooleanValue(c_GrabCursorOptionKey, "on", true);
-        pGrabMouse_->setChecked(grabCursorEnabled);
+        pStartupScreens_->buttonAction(MachGui::ButtonEvent::EXIT);
     }
 }
 

--- a/src/libdev/machgui/internal/startui.hpp
+++ b/src/libdev/machgui/internal/startui.hpp
@@ -63,7 +63,7 @@ private:
     int inGameResolutionWidth_;
     int inGameResolutionHeight_;
     int inGameResolutionRate_;
-    bool isGamePaused_;
+    bool isGamePaused_{};
     FocusCapableControls focusCapableControls_;
     MachGuiDispositionChangeNotifiable* pDispositionNotifiable_;
     bool ignoreHostLostSystemMessage_;


### PR DESCRIPTION
`pStartupScreens_->buttonAction(MachGui::ButtonEvent::EXIT);` destroys the Options context, so the access of pGrabMouse_ is invalid.

I should have put the new `pGrabMouse_->setChecked(grabCursorEnabled);` before the EXIT event propagated to the parent but hmm, this code is not needed at all. We don't have any static vars and don't do magic there in the checkbox. It 'll be properly initialized on the next MachGuiCtxOptions instantiation.

Fixes regression after 408e0aeec37b6fb9e117cc9eda6202a495a0729d.